### PR TITLE
DPI-2892 Package htmlwidgets in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "htmlwidgets";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''A framework for creating HTML widgets that render in various
+    contexts including the R console, 'R Markdown' documents, and 'Shiny'
+    web applications.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    yaml
+    jsonlite
+    htmltools
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package htmlwidgets in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR